### PR TITLE
Fix missing quotes in issue manager config

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -24,7 +24,7 @@ jobs:
           config: >
             {
               "info-needed": {
-                "delay": P14D,
+                "delay": "P14D",
                 "message": "Hi, this issue requires extra info to be actionable. We're closing this issue because it has not been actionable for a while now. Feel free to provide the requested information and we'll happily open it again! 😊"
               }
             }


### PR DESCRIPTION
## Description

Forgot to add quotes during the last minute switch from a seconds based period to an ISO 8601 based period for the delay in #3556 :melting_face:

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a minor but critical bug in the GitHub issue manager workflow configuration. It corrects the syntax for specifying the delay period, ensuring the automated issue management process functions as intended.

- **Bug Fixes**:
    - Fixed a syntax error in the issue manager configuration by adding missing quotes around the ISO 8601 duration string.

<!-- Generated by sourcery-ai[bot]: end summary -->